### PR TITLE
Check 21.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,10 @@ This script installs GVM, alias OpenVAS. It is not made for docker, but VMs and 
 Set the following environment variables as for your need.
 
 - `GVM_INSTALL_PREFIX`: Path to the gvm user directory. (default = */var/opt/gvm*)
-- `GVM_VERSION`: GVM version to install. (example = *20.08*)
+- `GVM_VERSION`: GVM version to install. (default = *21.04*)
 - `GVM_ADMIN_PWD`: Initial admin password. (default = *admin*)
 
 ```bash
-$ export GVM_VERSION=20.08
 $ ./install.sh
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -167,7 +167,7 @@ function setup_user() {
         usermod -c "GVM/OpenVAS user" -d "$GVM_INSTALL_PREFIX" -m -s /bin/bash -aG redis gvm
     fi
     echo "export PATH=\"\$PATH:$GVM_INSTALL_PREFIX/bin:$GVM_INSTALL_PREFIX/sbin:$GVM_INSTALL_PREFIX/.local/bin\"" \
-        | tee -a /etc/profile.d/gvm.sh
+        | tee /etc/profile.d/gvm.sh
     chmod 755 /etc/profile.d/gvm.sh
     . /etc/profile.d/gvm.sh
     cat << EOF > /etc/ld.so.conf.d/gvm.conf
@@ -182,9 +182,12 @@ function system_tweaks() {
     set -e
     sysctl -w net.core.somaxconn=1024
     sysctl vm.overcommit_memory=1
-    # TODO: check for their existence
-    echo 'net.core.somaxconn=1024'  >> /etc/sysctl.conf
-    echo 'vm.overcommit_memory=1' >> /etc/sysctl.conf
+    if [ -z "$(grep -o 'net.core.somaxconn=' /etc/sysctl.conf)"  ]; then
+        echo 'net.core.somaxconn=1024'  >> /etc/sysctl.conf
+    fi
+    if [ -z "$(grep -o 'vm.overcommit_memory=' /etc/sysctl.conf)"  ]; then
+        echo 'vm.overcommit_memory=1' >> /etc/sysctl.conf
+    fi
     cat << EOF > /etc/systemd/system/disable-thp.service
 [Unit]
 Description=Disable Transparent Huge Pages (THP)
@@ -209,19 +212,19 @@ function clone_sources() {
     set -e
     cd ~/src
     git clone -b "gvm-libs-$GVM_VERSION" --single-branch https://github.com/greenbone/gvm-libs.git \
-        || (cd gvm-libs; git pull; cd ..)
+        || (cd gvm-libs; git pull --all; git checkout "gvm-libs-$GVM_VERSION"; git pull; cd ..)
     git clone -b "openvas-$GVM_VERSION" --single-branch https://github.com/greenbone/openvas.git \
-        || (cd openvas; git pull; cd ..)
+        || (cd openvas; git pull --all; git checkout "openvas-$GVM_VERSION"; git pull; cd ..)
     git clone -b "gvmd-$GVM_VERSION" --single-branch https://github.com/greenbone/gvmd.git \
-        || (cd gvmd; git pull; cd ..)
+        || (cd gvmd; git pull --all; git checkout "gvmd-$GVM_VERSION"; git pull; cd ..)
     git clone -b master --single-branch https://github.com/greenbone/openvas-smb.git \
         || (cd openvas-smb; git pull; cd ..)
     git clone -b "gsa-$GVM_VERSION" --single-branch https://github.com/greenbone/gsa.git \
-        || (cd gsa; git pull; cd ..)
+        || (cd gsa; git pull --all; git checkout "gsa-$GVM_VERSION"; git pull; cd ..)
     git clone -b "ospd-openvas-$GVM_VERSION" --single-branch https://github.com/greenbone/ospd-openvas.git \
-        || (cd ospd-openvas; git pull; cd ..)
+        || (cd ospd-openvas; git pull --all; git checkout "ospd-openvas-$GVM_VERSION"; git pull; cd ..)
     git clone -b "ospd-$GVM_VERSION" --single-branch https://github.com/greenbone/ospd.git \
-        || (cd ospd; git pull; cd ..)
+        || (cd ospd; git pull --all; git checkout "ospd-$GVM_VERSION"; git pull; cd ..)
 }
 
 exec_as gvm clone_sources GVM_VERSION

--- a/install.sh
+++ b/install.sh
@@ -94,6 +94,7 @@ function print_help() {
     echo '  GVM_INSTALL_PREFIX : Path to the gvm user directory. (default = /var/opt/gvm)'
     echo '  GVM_VERSION        : GVM version to install.'
     echo '  GVM_ADMIN_PWD      : Initial admin password. (default = admin)'
+    echo '  GVM_GSAD_OPTS      : Options to pass into gsad service, refer to "gsad --help". (eg. SSL certificate)'
     echo ''
 }
 
@@ -111,7 +112,7 @@ done
 ### ARGUMENTS ###
 
 export GVM_INSTALL_PREFIX="${GVM_INSTALL_PREFIX:-/var/opt/gvm}"
-export GVM_VERSION="${GVM_VERSION:-}"
+export GVM_VERSION="${GVM_VERSION:-21.04}"
 export GVM_ADMIN_PWD="${GVM_ADMIN_PWD:-admin}"
 
 require GVM_INSTALL_PREFIX
@@ -119,6 +120,8 @@ require GVM_VERSION
 require GVM_ADMIN_PWD
 
 ### INSTALL ###
+
+$AS_ROOT "systemctl stop gvmd.service gsad.service ospd-openvas.service || true"
 
 function update_system() {
     set -e
@@ -146,7 +149,7 @@ function install_deps() {
         python3-polib python3-dev redis redis-server rpm rsync smbclient \
         snmp socat software-properties-common sshpass \
         texlive-fonts-recommended texlive-latex-extra uuid-dev \
-        vim virtualenv wget xmltoman xml-twig-tools xsltproc
+        vim virtualenv wget xmltoman xml-twig-tools xsltproc libnet1-dev libunistring-dev
     curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
     echo 'deb https://dl.yarnpkg.com/debian/ stable main' \
         | tee /etc/apt/sources.list.d/yarn.list
@@ -182,10 +185,10 @@ function system_tweaks() {
     set -e
     sysctl -w net.core.somaxconn=1024
     sysctl vm.overcommit_memory=1
-    if [ -z "$(grep -o 'net.core.somaxconn=' /etc/sysctl.conf)"  ]; then
+    if [ -z "$(grep -o 'net.core.somaxconn' /etc/sysctl.conf)"  ]; then
         echo 'net.core.somaxconn=1024'  >> /etc/sysctl.conf
     fi
-    if [ -z "$(grep -o 'vm.overcommit_memory=' /etc/sysctl.conf)"  ]; then
+    if [ -z "$(grep -o 'vm.overcommit_memory' /etc/sysctl.conf)"  ]; then
         echo 'vm.overcommit_memory=1' >> /etc/sysctl.conf
     fi
     cat << EOF > /etc/systemd/system/disable-thp.service
@@ -211,19 +214,19 @@ $AS_GVM "mkdir -p ~/src"
 function clone_sources() {
     set -e
     cd ~/src
-    git clone -b "gvm-libs-$GVM_VERSION" --single-branch https://github.com/greenbone/gvm-libs.git \
+    git clone -b "gvm-libs-$GVM_VERSION" https://github.com/greenbone/gvm-libs.git \
         || (cd gvm-libs; git pull --all; git checkout "gvm-libs-$GVM_VERSION"; git pull; cd ..)
-    git clone -b "openvas-$GVM_VERSION" --single-branch https://github.com/greenbone/openvas.git \
+    git clone -b "openvas-$GVM_VERSION" https://github.com/greenbone/openvas.git \
         || (cd openvas; git pull --all; git checkout "openvas-$GVM_VERSION"; git pull; cd ..)
-    git clone -b "gvmd-$GVM_VERSION" --single-branch https://github.com/greenbone/gvmd.git \
+    git clone -b "gvmd-$GVM_VERSION" https://github.com/greenbone/gvmd.git \
         || (cd gvmd; git pull --all; git checkout "gvmd-$GVM_VERSION"; git pull; cd ..)
     git clone -b master --single-branch https://github.com/greenbone/openvas-smb.git \
         || (cd openvas-smb; git pull; cd ..)
-    git clone -b "gsa-$GVM_VERSION" --single-branch https://github.com/greenbone/gsa.git \
+    git clone -b "gsa-$GVM_VERSION" https://github.com/greenbone/gsa.git \
         || (cd gsa; git pull --all; git checkout "gsa-$GVM_VERSION"; git pull; cd ..)
-    git clone -b "ospd-openvas-$GVM_VERSION" --single-branch https://github.com/greenbone/ospd-openvas.git \
+    git clone -b "ospd-openvas-$GVM_VERSION" https://github.com/greenbone/ospd-openvas.git \
         || (cd ospd-openvas; git pull --all; git checkout "ospd-openvas-$GVM_VERSION"; git pull; cd ..)
-    git clone -b "ospd-$GVM_VERSION" --single-branch https://github.com/greenbone/ospd.git \
+    git clone -b "ospd-$GVM_VERSION" https://github.com/greenbone/ospd.git \
         || (cd ospd; git pull --all; git checkout "ospd-$GVM_VERSION"; git pull; cd ..)
 }
 
@@ -334,6 +337,7 @@ exec_as postgres setup_postgres
 function setup_gvmd() {
     set -e
     . /etc/profile.d/gvm.sh
+    gvmd --migrate
     gvm-manage-certs -af
     gvmd --get-users | grep admin || gvmd --create-user=admin --password="$GVM_ADMIN_PWD"
     # set feed owner
@@ -421,7 +425,7 @@ Wants=gvmd.service
 Type=forking
 PIDFile=$GVM_INSTALL_PREFIX/var/run/gsad.pid
 WorkingDirectory=$GVM_INSTALL_PREFIX
-ExecStart=$GVM_INSTALL_PREFIX/sbin/gsad --drop-privileges=gvm
+ExecStart=$GVM_INSTALL_PREFIX/sbin/gsad --drop-privileges=gvm $GVM_GSAD_OPTS
 Restart=on-failure
 RestartSec=2min
 KillMode=process


### PR DESCRIPTION
This PR introduces different improvements.
It should now be (finally) possible to rerun this script to update a gvm installation.
Also the new release 21.04 is not only working, but used as default.

I've verified these things on my own installation. __WORKS ON MY MACHINE__